### PR TITLE
Change License owner to 'Dono - Password Derivation Tool'

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
 Dono Android - Password Derivation Tool
-Copyright (C) 2016  Panos Sakkos
+Copyright (C) 2016  Dono - Password Derivation Tool
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
 If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-Dono Android - Password Derivation Tool  Copyright (C) 2016  Panos Sakkos
+Dono Android - Password Derivation Tool  Copyright (C) 2016  Dono - Password Derivation Tool
 This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type `show c' for details.

--- a/src/app/src/main/java/com/dono/psakkos/dono/DonoToastFactory.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/DonoToastFactory.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/LabelAdapter.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/LabelAdapter.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/MainActivity.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/MainActivity.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/core/Dono.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/core/Dono.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/core/PersistableKey.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/core/PersistableKey.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/core/PersistableLabels.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/core/PersistableLabels.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/AddLabelFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/AddLabelFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/DonoFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/DonoFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/EmptyFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/EmptyFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/KeyFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/KeyFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/LabelsFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/LabelsFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/main/java/com/dono/psakkos/dono/fragments/LonelyFragment.java
+++ b/src/app/src/main/java/com/dono/psakkos/dono/fragments/LonelyFragment.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/test/java/com/dono/psakkos/dono/DonoCoreConstantsTests.java
+++ b/src/app/src/test/java/com/dono/psakkos/dono/DonoCoreConstantsTests.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/app/src/test/java/com/dono/psakkos/dono/DonoCoreKeyDerivationUnitTests.java
+++ b/src/app/src/test/java/com/dono/psakkos/dono/DonoCoreKeyDerivationUnitTests.java
@@ -1,5 +1,5 @@
 // Dono Android - Password Derivation Tool
-// Copyright (C) 2016  Panos Sakkos
+// Copyright (C) 2016  Dono - Password Derivation Tool
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Changed in 16 places. Issue #26 